### PR TITLE
Add getCurrentPosition() to public methods

### DIFF
--- a/library/src/com/dd/crop/CropTextureView.java
+++ b/library/src/com/dd/crop/CropTextureView.java
@@ -372,6 +372,13 @@ public class CropTextureView extends TextureView implements TextureView.SurfaceT
     public int getDuration() {
         return mMediaPlayer.getDuration();
     }
+    
+     /**
+     * @see android.media.MediaPlayer#getCurrentPosition()
+     */
+    public int getCurrentPosition() {
+        return mMediaPlayer.getCurrentPosition();
+    }
 
     static void log(String message) {
         if (LOG_ON) {


### PR DESCRIPTION
Hello,
in my opinion it would be useful to have a method that returns the current position of the underlining MediaPlayer.
